### PR TITLE
5 update colour scheme

### DIFF
--- a/components/Header.module.css
+++ b/components/Header.module.css
@@ -15,10 +15,10 @@
 }
 
 .discord a {
-  background: rgba(0,0,0,0.25);
+  background: rgb(244, 197, 36);
   padding: 16px 32px;
   border-radius: 500px;
-  color: #fff;
+  color: #000;
   text-decoration: none;
   transition: all ease-in-out 150ms;
   white-space: nowrap;
@@ -27,5 +27,5 @@
 
 .discord a:hover,
 .discord a:focus { 
-  background: rgba(0,0,0,0.5);
+  background: rgba(244, 197, 36,.5);
 }

--- a/components/Streamer.module.css
+++ b/components/Streamer.module.css
@@ -1,6 +1,6 @@
 .Streamer {
     display: inline-block;
-    box-shadow: 0px 8px 32px -8px rgba(0,0,0,0.75);
+    box-shadow: 0px 8px 32px -8px rgb(0,0,0);
     background: #fff;
     overflow: hidden;
     text-decoration: 0;
@@ -15,7 +15,7 @@ div:hover > .Streamer:not(:hover) .StreamerThumbnail {
 }
 
 .Streamer:hover {
-    box-shadow: 0px 32px 64px -8px rgba(0,0,0,0.5);
+    box-shadow: 0px 32px 64px -8px rgb(0,0,0);
     transform: translate3d(0,-8px,0);
 
 }

--- a/components/Streamer.module.css
+++ b/components/Streamer.module.css
@@ -4,7 +4,7 @@
     background: #fff;
     overflow: hidden;
     text-decoration: 0;
-    color: #989ca4;
+    color: #000000;
     transition: all ease-in-out 150ms;
     transform: translate3d(0,0,0);
     max-width: 600px;
@@ -67,7 +67,7 @@ div:hover > .Streamer:not(:hover) .StreamerThumbnail {
     display: flex;
     align-items: center;
     margin: 0;
-    color: #69706c;
+    color: #000000;
     font-weight: 800;
 }
 


### PR DESCRIPTION
Sets streamer text to black. Removes alpha channel from boxshadow applied to streamer cards to make the boxshadow visible against the dark background. Changes discord button to yellow with black text.